### PR TITLE
Foldr func

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ These functions can be generated for every type.
 | `Filter`     | `[a] -> (a -> bool) -> [a]`      |   ✓    |   ✓    |    ✓   | Filter the slice based on a predicate|
 | `Foldl`      | `[a] -> a -> (a -> a -> a) -> a` |   ✓    |   ✓    |    ✓   | Left fold over the slice to reduce it to one element with starting value.|
 | `Foldl1`     | `[a] -> (a -> a -> a) -> a`      |   ✓    |   ✓    |    ✓   | Left fold over the slice to reduce it to one element.|
+| `Foldr`      | `[a] -> b -> (a -> b -> b) -> b` |   ✓    |   ✓    |    ✓   | Right fold over the slice to reduce it to one element with a starting value. |
 | `Group`      | `[a] -> [[a]]`                   |   ✓    |   ✓    |    ✓   | Returns a list of lists where each list contains grouped values from the input list.|
 | `Head`       | `[a] -> a`                       |   ✓    |   ✓    |    ✓   | Return the first element|
 | `Init`       | `[a] -> [a]`                     |   ✓    |   ✓    |    ✓   | Returns all elements minus the last|

--- a/functions/foldr.go
+++ b/functions/foldr.go
@@ -1,0 +1,17 @@
+package functions
+
+// Foldr reduces a list by iteratively applying f from right -> left. Thus, for an empty slice, the result is the default zero-value.
+func (s SliceType) Foldr(e ElementType, f func(e1, e2 ElementType) ElementType) (out ElementType) {
+	if len(s) == 0 {
+		return
+	}
+
+	end := len(s) - 1
+	out = f(s[end], e)
+
+	for i := end - 1; i >= 0; i-- {
+		out = f(s[i], out)
+	}
+
+	return
+}

--- a/functions/main.go
+++ b/functions/main.go
@@ -38,6 +38,7 @@ var (
 		"filter.go":      {ForNumbers, ForStrings, ForStructs},
 		"foldl.go":       {ForNumbers, ForStrings, ForStructs},
 		"foldl1.go":      {ForNumbers, ForStrings, ForStructs},
+		"foldr.go":       {ForNumbers, ForStrings, ForStructs},
 		"group.go":       {ForNumbers, ForStrings, ForStructs},
 		"head.go":        {ForNumbers, ForStrings, ForStructs},
 		"init.go":        {ForNumbers, ForStrings, ForStructs},

--- a/template.go
+++ b/template.go
@@ -181,6 +181,23 @@ func (s SliceType) Foldl1(f func(e1, e2 ElementType) ElementType) (out ElementTy
 	return
 }
 `,
+	"foldr.go": `
+// Foldr reduces a list by iteratively applying f from right -> left. Thus, for an empty slice, the result is the default zero-value.
+func (s SliceType) Foldr(e ElementType, f func(e1, e2 ElementType) ElementType) (out ElementType) {
+	if len(s) == 0 {
+		return
+	}
+
+	end := len(s) - 1
+	out = f(s[end], e)
+
+	for i := end - 1; i >= 0; i-- {
+		out = f(s[i], out)
+	}
+
+	return
+}
+`,
 	"group.go": `
 // Group returns a list of lists where each list contains only equal elements and the concatenation of the
 // result is equal to the argument.
@@ -602,6 +619,7 @@ var funcDomains = map[string][]string{
 	"filter.go":      {ForNumbers, ForStrings, ForStructs},
 	"foldl.go":       {ForNumbers, ForStrings, ForStructs},
 	"foldl1.go":      {ForNumbers, ForStrings, ForStructs},
+	"foldr.go":       {ForNumbers, ForStrings, ForStructs},
 	"group.go":       {ForNumbers, ForStrings, ForStructs},
 	"head.go":        {ForNumbers, ForStrings, ForStructs},
 	"init.go":        {ForNumbers, ForStrings, ForStructs},

--- a/types/Ints_hasgo.go
+++ b/types/Ints_hasgo.go
@@ -194,6 +194,24 @@ func (s Ints) Foldl1(f func(e1, e2 int64) int64) (out int64) {
 	return
 }
 
+// =============== foldr.go =================
+
+// Foldr reduces a list by iteratively applying f from right -> left. Thus, for an empty slice, the result is the default zero-value.
+func (s Ints) Foldr(e int64, f func(e1, e2 int64) int64) (out int64) {
+	if len(s) == 0 {
+		return
+	}
+
+	end := len(s) - 1
+	out = f(s[end], e)
+
+	for i := end - 1; i >= 0; i-- {
+		out = f(s[i], out)
+	}
+
+	return
+}
+
 // =============== group.go =================
 
 // Group returns a list of lists where each list contains only equal elements and the concatenation of the

--- a/types/Ints_test.go
+++ b/types/Ints_test.go
@@ -520,11 +520,13 @@ var (
 		foldfunc func(int64, int64) int64
 		foldl    int64
 		foldl1   int64
+		foldr    int64
 	}{
 		{
 			nil,
 			0,
 			func(i1, i2 int64) int64 { return i1 + i2 },
+			0,
 			0,
 			0,
 		},
@@ -534,6 +536,7 @@ var (
 			func(i1, i2 int64) int64 { return i1 + i2 },
 			2,
 			1,
+			2,
 		},
 		{
 			Ints{1, 2, 3, 4, 5},
@@ -541,6 +544,7 @@ var (
 			func(i1, i2 int64) int64 { return i1 - i2 },
 			-13,
 			-13,
+			3,
 		},
 	}
 
@@ -1132,6 +1136,16 @@ func Test_IntsFoldl1(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			if res := test.input.Foldl1(test.foldfunc); res != test.foldl1 {
 				t.Errorf("expected %v but got %v", test.foldl1, res)
+			}
+		})
+	}
+}
+
+func Test_IntsFoldr(t *testing.T) {
+	for _, test := range intsFoldTests {
+		t.Run("", func(t *testing.T) {
+			if res := test.input.Foldr(test.init, test.foldfunc); res != test.foldr {
+				t.Errorf("expected #{test.foldr} but got #{res}")
 			}
 		})
 	}

--- a/types/Persons_test.go
+++ b/types/Persons_test.go
@@ -304,16 +304,18 @@ var (
 	}
 
 	structFoldTests = []struct {
-		input     persons
-		init      person
-		foldlfunc func(p1, p2 person) person
-		foldl     person
-		foldl1    person
+		input    persons
+		init     person
+		foldfunc func(p1, p2 person) person
+		foldl    person
+		foldl1   person
+		foldr    person
 	}{
 		{
 			nil,
 			person{},
 			func(p1, p2 person) person { return p1 },
+			person{},
 			person{},
 			person{},
 		},
@@ -326,6 +328,7 @@ var (
 				}
 				return p2
 			},
+			ana,
 			ana,
 			ana,
 		},
@@ -825,7 +828,7 @@ func Test_structMaximumBy(t *testing.T) {
 func Test_structFoldl(t *testing.T) {
 	for _, test := range structFoldTests {
 		t.Run("", func(t *testing.T) {
-			if res := test.input.Foldl(test.init, test.foldlfunc); res != test.foldl {
+			if res := test.input.Foldl(test.init, test.foldfunc); res != test.foldl {
 				t.Errorf("expected %v but got %v", test.foldl, res)
 			}
 		})
@@ -835,8 +838,18 @@ func Test_structFoldl(t *testing.T) {
 func Test_structFoldl1(t *testing.T) {
 	for _, test := range structFoldTests {
 		t.Run("", func(t *testing.T) {
-			if res := test.input.Foldl1(test.foldlfunc); res != test.foldl1 {
+			if res := test.input.Foldl1(test.foldfunc); res != test.foldl1 {
 				t.Errorf("expected %v but got %v", test.foldl1, res)
+			}
+		})
+	}
+}
+
+func Test_structFoldr(t *testing.T) {
+	for _, test := range structFoldTests {
+		t.Run("", func(t *testing.T) {
+			if res := test.input.Foldr(test.init, test.foldfunc); res != test.foldr {
+				t.Errorf("expected %v but got %v", test.foldr, res)
 			}
 		})
 	}

--- a/types/Strings_hasgo.go
+++ b/types/Strings_hasgo.go
@@ -167,6 +167,24 @@ func (s Strings) Foldl1(f func(e1, e2 string) string) (out string) {
 	return
 }
 
+// =============== foldr.go =================
+
+// Foldr reduces a list by iteratively applying f from right -> left. Thus, for an empty slice, the result is the default zero-value.
+func (s Strings) Foldr(e string, f func(e1, e2 string) string) (out string) {
+	if len(s) == 0 {
+		return
+	}
+
+	end := len(s) - 1
+	out = f(s[end], e)
+
+	for i := end - 1; i >= 0; i-- {
+		out = f(s[i], out)
+	}
+
+	return
+}
+
 // =============== group.go =================
 
 // Group returns a list of lists where each list contains only equal elements and the concatenation of the

--- a/types/Strings_test.go
+++ b/types/Strings_test.go
@@ -405,11 +405,12 @@ var (
 	}
 
 	stringsFoldTests = []struct {
-		input     Strings
-		init      string
-		foldlfunc func(s1, s2 string) string
-		foldl     string
-		foldl1    string
+		input    Strings
+		init     string
+		foldfunc func(s1, s2 string) string
+		foldl    string
+		foldl1   string
+		foldr    string
 	}{
 		{
 			nil,
@@ -417,11 +418,13 @@ var (
 			func(s1, s2 string) string { return s1 },
 			"",
 			"",
+			"",
 		},
 		{
 			Strings{},
 			"",
 			func(s1, s2 string) string { return s1 },
+			"",
 			"",
 			"",
 		},
@@ -433,6 +436,7 @@ var (
 			},
 			"one zero",
 			"one",
+			"one zero",
 		},
 		{
 			Strings{"one", "two", "three", "ten"},
@@ -443,6 +447,7 @@ var (
 				}
 				return s2
 			},
+			"three",
 			"three",
 			"three",
 		},
@@ -979,7 +984,7 @@ func Test_StringsWords(t *testing.T) {
 func Test_StringsFoldl1(t *testing.T) {
 	for _, test := range stringsFoldTests {
 		t.Run("", func(t *testing.T) {
-			if res := test.input.Foldl1(test.foldlfunc); res != test.foldl1 {
+			if res := test.input.Foldl1(test.foldfunc); res != test.foldl1 {
 				t.Errorf("expected %v but got %v", test.foldl1, res)
 			}
 		})
@@ -989,8 +994,18 @@ func Test_StringsFoldl1(t *testing.T) {
 func Test_StringsFoldl(t *testing.T) {
 	for _, test := range stringsFoldTests {
 		t.Run("", func(t *testing.T) {
-			if res := test.input.Foldl(test.init, test.foldlfunc); res != test.foldl {
+			if res := test.input.Foldl(test.init, test.foldfunc); res != test.foldl {
 				t.Errorf("expected %v but got %v", test.foldl, res)
+			}
+		})
+	}
+}
+
+func Test_StringsFoldr(t *testing.T) {
+	for _, test := range stringsFoldTests {
+		t.Run("", func(t *testing.T) {
+			if res := test.input.Foldr(test.init, test.foldfunc); res != test.foldr {
+				t.Errorf("expected %v but got %v", test.foldr, res)
 			}
 		})
 	}

--- a/types/persons_hasgo.go
+++ b/types/persons_hasgo.go
@@ -166,6 +166,24 @@ func (s persons) Foldl1(f func(e1, e2 person) person) (out person) {
 	return
 }
 
+// =============== foldr.go =================
+
+// Foldr reduces a list by iteratively applying f from right -> left. Thus, for an empty slice, the result is the default zero-value.
+func (s persons) Foldr(e person, f func(e1, e2 person) person) (out person) {
+	if len(s) == 0 {
+		return
+	}
+
+	end := len(s) - 1
+	out = f(s[end], e)
+
+	for i := end - 1; i >= 0; i-- {
+		out = f(s[i], out)
+	}
+
+	return
+}
+
 // =============== group.go =================
 
 // Group returns a list of lists where each list contains only equal elements and the concatenation of the


### PR DESCRIPTION
I kept the element order of Foldl in Hasgo (`[a] -> a -> (a -> a -> a) -> a`) although Haskell defines it as `(a -> b -> b) -> b -> [a] -> b` which is Hasgo *would* be `[a] -> (a -> a -> a) -> a -> a`.

Need to verify that this is how we want to keep it prior to merge @DylanMeeus.